### PR TITLE
Made so that when the string has simple quotes (') they are escaped; als...

### DIFF
--- a/consolewrap.py
+++ b/consolewrap.py
@@ -38,7 +38,7 @@ class ConsolewrapCommand(sublime_plugin.TextCommand):
         if lang == 'rb':
             return "\n%sputs '-----------------------------[log][auto][%s]:';p %s" % (spaces, var_text_escaped, var_text)
         elif lang == 'erb':
-            return "\n<%% %sputs '-----------------------------[log][auto][%s]:';p %s %%>" % (spaces, var_text_escaped, var_text)
+            return "\n%s<%% puts '-----------------------------[log][auto][%s]:';p %s %%>" % (spaces, var_text_escaped, var_text)
         else:
             return "\n%sconsole.log('%s ' , %s);" % (spaces, var_text_escaped, var_text)
 


### PR DESCRIPTION
Made it so that when the string has simple quotes (') they are escaped; also, if the selection ends with a semi collon (;) this char is striped out.
