### PR TITLE
Remove unnecessary spaces from log

### DIFF
--- a/consolewrap.py
+++ b/consolewrap.py
@@ -40,7 +40,7 @@ class ConsolewrapCommand(sublime_plugin.TextCommand):
         elif lang == 'erb':
             return "\n%s<%% puts '-----------------------------[log][auto][%s]:';p %s %%>" % (spaces, var_text_escaped, var_text)
         else:
-            return "\n%sconsole.log('%s ' , %s);" % (spaces, var_text_escaped, var_text)
+            return "\n%sconsole.log('%s', %s);" % (spaces, var_text_escaped, var_text)
 
 
 class ConsoleremoveCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
`console.log` arguments are already spaced